### PR TITLE
CRUD improvements

### DIFF
--- a/app/services/data/dynamodb/DynamoDBPersonsRepository.scala
+++ b/app/services/data/dynamodb/DynamoDBPersonsRepository.scala
@@ -57,6 +57,7 @@ class DynamoDBPersonsRepository @Inject()(client: DynamoDBClient)
             case Xor.Left(dynamoReadError) => dynamoReadError
           }
 
+          // Each individual result has the potential to fail and so we capture this
           badResults.foreach((dynamoError: DynamoReadError) => log.error(s"all: ${describe(dynamoError)}"))
 
           val goodResults = listXor.collect {


### PR DESCRIPTION
- Try-catch unnecessary since we are using `Future`s, instead this has been replaced with `recover` in case the `Future` itself fails since we do optimistic future transformations throughout
- Use an idiomatic `fold` over pattern matching for `Xor` in `find`
- capture recover duplication into `captureAndFail`
